### PR TITLE
add logic for serato import and export and enable dev local testing.

### DIFF
--- a/subbox_landing/config/config.prod.yaml
+++ b/subbox_landing/config/config.prod.yaml
@@ -6,4 +6,4 @@ application_settings:
   app_host: 0.0.0.0
   app_port: 8888
 pymix:
-  addr: 0.0.0.0:8002
+  addr: pymix:8002

--- a/subbox_landing/routers/about.py
+++ b/subbox_landing/routers/about.py
@@ -6,12 +6,12 @@ from fastapi.templating import Jinja2Templates
 router = APIRouter()
 @router.get("/about", response_class=HTMLResponse)
 async def about(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("about.html", context)
 
 @router.get("/contact", response_class=HTMLResponse)
 async def contact(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("contact.html", context)

--- a/subbox_landing/routers/djs.py
+++ b/subbox_landing/routers/djs.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 from unittest import mock
 from http import HTTPStatus
 
@@ -13,43 +13,43 @@ from subbox_landing.containers import Container
 router = APIRouter()
 @router.get("/djs", response_class=HTMLResponse)
 async def djs(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("djs.html", context)
 
 @router.get("/djs-import", response_class=HTMLResponse)
 async def djs(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("dj/djs_import.html", context)
 
 @router.get("/djs-export", response_class=HTMLResponse)
 async def djs(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("dj/djs_export.html", context)
 
 @router.get("/rb-import", response_class=HTMLResponse)
 async def djs(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("dj/rb_import.html", context)
 
 @router.get("/rb-export", response_class=HTMLResponse)
 async def djs(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("dj/rb_export.html", context)
 
 @router.get("/serato-import", response_class=HTMLResponse)
 async def djs(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("dj/serato_import.html", context)
 
 @router.get("/serato-export", response_class=HTMLResponse)
 async def djs(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("dj/serato_export.html", context)
 @router.post("/djs/upload/rekordbox", response_class=HTMLResponse)
@@ -58,9 +58,10 @@ async def upload_rekordbox(
         request: Request,
         session_id: str | None = Cookie(None),
         hx_request: Optional[str] = Header(None),
+        config: Dict = Provide[Container.config],
         session: ClientSession = Depends(Provide[Container.aiohttp_session])
 ):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
 
     success = False
     context = {"request": request}
@@ -70,7 +71,7 @@ async def upload_rekordbox(
         data = {
             'session_id': session_id
         }
-        async with session.post('http://pymix:8002/rekordbox/import', params=data) as response:
+        async with session.post(f'http://{config["pymix"]["addr"]}/rekordbox/import', params=data) as response:
             status_code = response.status
             if response.status == HTTPStatus.OK:
                 response_json = await response.json()
@@ -97,10 +98,11 @@ async def export_rekordbox(
         request: Request,
         session_id: str | None = Cookie(None),
         local_root: str = Form(...),
+        config: Dict = Provide[Container.config],
         session: ClientSession = Depends(Provide[Container.aiohttp_session])
 ):
     print(local_root)
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
 
     success = False
     context = {"request": request}
@@ -111,7 +113,7 @@ async def export_rekordbox(
             'session_id': session_id,
             'user_root': local_root
         }
-        async with session.post('http://pymix:8002/rekordbox/export', params=data) as response:
+        async with session.post(f'http://{config["pymix"]["addr"]}/rekordbox/export', params=data) as response:
             status_code = response.status
             if response.status == HTTPStatus.OK:
                 response_json = await response.json()
@@ -127,6 +129,87 @@ async def export_rekordbox(
             'status_code': status_code,
             'response': response_json,
             'message': f'Failed to complete export job for session id {session_id}'
+        }
+        template = templates.TemplateResponse("partials/generic_failure.html", context)
+    return template
+
+@router.post("/djs/export/serato", response_class=HTMLResponse)
+@inject
+async def export_serato(
+        request: Request,
+        session_id: str | None = Cookie(None),
+        local_root: str = Form(...),
+        config: Dict = Provide[Container.config],
+        session: ClientSession = Depends(Provide[Container.aiohttp_session])
+):
+    print(local_root)
+    templates = Jinja2Templates(directory="ui/templates")
+
+    success = False
+    context = {"request": request}
+    status_code = None
+    response_json = ""
+    if session_id or isinstance(session, mock.AsyncMock):
+        data = {
+            'session_id': session_id,
+            'user_root': local_root
+        }
+        async with session.post(f'http://{config["pymix"]["addr"]}/serato/export', params=data) as response:
+            status_code = response.status
+            if response.status == HTTPStatus.OK:
+                response_json = await response.json()
+                print(response_json)
+                success = True
+                n_beets_tracks = response_json['n_beets_tracks']
+                context['n_beets_tracks'] = n_beets_tracks
+
+    if success:
+        template = templates.TemplateResponse("partials/serato_export_results.html", context)
+    else:
+        context["error"] = {
+            'status_code': status_code,
+            'response': response_json,
+            'message': f'Failed to complete export job for session id {session_id}'
+        }
+        template = templates.TemplateResponse("partials/generic_failure.html", context)
+    return template
+
+@router.post("/djs/upload/serato", response_class=HTMLResponse)
+@inject
+async def upload_serato(
+        request: Request,
+        session_id: str | None = Cookie(None),
+        hx_request: Optional[str] = Header(None),
+        config: Dict = Provide[Container.config],
+        session: ClientSession = Depends(Provide[Container.aiohttp_session])
+):
+    templates = Jinja2Templates(directory="ui/templates")
+
+    success = False
+    context = {"request": request}
+    status_code = None
+    response_json = ""
+    if session_id or isinstance(session, mock.AsyncMock):
+        data = {
+            'session_id': session_id
+        }
+        async with session.post(f'http://{config["pymix"]["addr"]}/serato/import', params=data) as response:
+            status_code = response.status
+            if response.status == HTTPStatus.OK:
+                response_json = await response.json()
+                success = response_json['success']
+                total_n_imported_tracks = response_json['imported_tracks']
+                beets_output = response_json['beets_output']
+                context['total_n_imported_tracks'] = total_n_imported_tracks
+                context['beets_output'] = beets_output
+
+    if success:
+        template = templates.TemplateResponse("partials/job_results.html", context)
+    else:
+        context["error"] = {
+            'status_code': status_code,
+            'response': response_json,
+            'message': f'Failed to complete import job for session id {session_id}'
         }
         template = templates.TemplateResponse("partials/generic_failure.html", context)
     return template

--- a/subbox_landing/routers/files.py
+++ b/subbox_landing/routers/files.py
@@ -6,48 +6,48 @@ from fastapi.responses import FileResponse
 router = APIRouter()
 @router.get("/imgs/spin", response_class=FileResponse)
 async def spin(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/spin.svg"
+    file_location = os.getcwd() + "/ui/templates/imgs/spin.svg"
     return FileResponse(file_location)
 
 @router.get("/imgs/bars", response_class=FileResponse)
 async def spin(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/bars.svg"
+    file_location = os.getcwd() + "/ui/templates/imgs/bars.svg"
     return FileResponse(file_location)
 
 @router.get("/imgs/upload", response_class=FileResponse)
 async def spin(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/upload.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/upload.png"
     return FileResponse(file_location)
 
 @router.get("/imgs/process", response_class=FileResponse)
 async def spin(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/process.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/process.png"
     return FileResponse(file_location)
 
 @router.get("/imgs/listen", response_class=FileResponse)
 async def spin(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/listen.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/listen.png"
     return FileResponse(file_location)
 
 @router.get("/imgs/rb-import-enable-xml", response_class=FileResponse)
 async def rb_import_enable_xml(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/RB-import-enable-xml.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/RB-import-enable-xml.png"
     return FileResponse(file_location)
 @router.get("/imgs/rb-import-set-xml-path", response_class=FileResponse)
 async def rb_import_set_xml_path(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/RB-import-set-xml-path.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/RB-import-set-xml-path.png"
     return FileResponse(file_location)
 @router.get("/imgs/rb-backup", response_class=FileResponse)
 async def rb_backup(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/RB-backup.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/RB-backup.png"
     return FileResponse(file_location)
 
 @router.get("/imgs/rb-backup-music-files", response_class=FileResponse)
 async def rb_backup_music_files(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/RB-backup-music-files.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/RB-backup-music-files.png"
     return FileResponse(file_location)
 
 @router.get("/imgs/player-screenshot", response_class=FileResponse)
 async def rb_backup_music_files(request: Request, hx_request: Optional[str] = Header(None)):
-    file_location = os.getcwd() + "/subbox_landing/ui/templates/imgs/player-screenshot.png"
+    file_location = os.getcwd() + "/ui/templates/imgs/player-screenshot.png"
     return FileResponse(file_location)

--- a/subbox_landing/routers/home.py
+++ b/subbox_landing/routers/home.py
@@ -6,6 +6,6 @@ from fastapi.templating import Jinja2Templates
 router = APIRouter()
 @router.get("/", response_class=HTMLResponse)
 async def home(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     context = {"request": request}
     return templates.TemplateResponse("home.html", context)

--- a/subbox_landing/routers/listen.py
+++ b/subbox_landing/routers/listen.py
@@ -8,7 +8,7 @@ router = APIRouter()
 
 @router.get("/listen", response_class=HTMLResponse)
 async def upload(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     response = templates.TemplateResponse('listen.html', {'request': request})
     return response
 
@@ -16,7 +16,7 @@ async def upload(request: Request, hx_request: Optional[str] = Header(None)):
 @router.get("/listen/player", response_class=HTMLResponse)
 async def filebrowser(request: Request, hx_request: Optional[str] = Header(None)):
     print('redirect')
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     data = {'msg': 'Logged in successfully'}
     response = templates.TemplateResponse('home.html', {'request': request, 'data': data})
     response.headers['HX-Redirect'] = 'https://player.sub-box.net/player/#'

--- a/subbox_landing/routers/process.py
+++ b/subbox_landing/routers/process.py
@@ -15,7 +15,7 @@ router = APIRouter()
 
 @router.get("/process", response_class=HTMLResponse)
 async def process(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     response = templates.TemplateResponse('process.html', {'request': request})
     return response
 
@@ -26,9 +26,10 @@ async def process_beets(
         request: Request,
         session_id: str | None = Cookie(None),
         hx_request: Optional[str] = Header(None),
+        config: dict = Provide[Container.config],
         session: ClientSession = Depends(Provide[Container.aiohttp_session]),
 ):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
 
     success = False
     context = {"request": request}
@@ -38,7 +39,7 @@ async def process_beets(
         data = {
             'session_id': session_id
         }
-        async with session.post('http://pymix:8002/beets/import', params=data) as response:
+        async with session.post(f'http://{config["pymix"]["addr"]}/beets/import', params=data) as response:
             status_code = response.status
             if response.status == HTTPStatus.OK:
                 response_json = await response.json()

--- a/subbox_landing/routers/upload.py
+++ b/subbox_landing/routers/upload.py
@@ -8,20 +8,20 @@ router = APIRouter()
 
 @router.get("/upload", response_class=HTMLResponse)
 async def upload(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     response = templates.TemplateResponse('upload.html', {'request': request})
     return response
 
 @router.get("/download", response_class=HTMLResponse)
 async def download(request: Request, hx_request: Optional[str] = Header(None)):
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     response = templates.TemplateResponse('download.html', {'request': request})
     return response
 
 @router.get("/upload/filebrowser", response_class=HTMLResponse)
 async def filebrowser(request: Request, hx_request: Optional[str] = Header(None)):
     print('redirect')
-    templates = Jinja2Templates(directory="subbox_landing/ui/templates")
+    templates = Jinja2Templates(directory="ui/templates")
     data = {'msg': 'Logged in successfully'}
     response = templates.TemplateResponse('home.html', {'request': request, 'data': data})
     response.headers['HX-Redirect'] = 'https://browser.sub-box.net/browser'

--- a/subbox_landing/ui/templates/dj/rb_export.html
+++ b/subbox_landing/ui/templates/dj/rb_export.html
@@ -17,7 +17,7 @@
                 <h1 class="subtitle is-3">RekordBox</h1>
                 <p>Tested with Rekordbox 5.8.7 and Rekordbox 6.8.0. It should also work with other rekordbox versions.</p>
                 <p>
-                    once you have made changes in sub box (e.g. adding more tracks, rating tracks or creating/modifying playlists) then you can export your changes to rekordbox (from rekordbox you can then export to USB for playback on your DJ system).
+                    export your collection and playlists in sub box to rekordbox (from rekordbox you can then export to USB for playback on your DJ system).
                 </p>
                 <p>
                     To get started, fill out the form below and click export.
@@ -44,7 +44,7 @@
                 </p>
                 <h1 class="subtitle is-4">Importing XML in to RekordBox</h1>
                 <p>
-                To do this go to Prefernces -> View -> check 'rekordbox xml' in Layout.
+                To do this go to Preferences -> View -> check 'rekordbox xml' in Layout.
                 </p>
                 <p>
                     <img src="/imgs/rb-import-enable-xml" width="604" height="448">

--- a/subbox_landing/ui/templates/dj/rb_import.html
+++ b/subbox_landing/ui/templates/dj/rb_import.html
@@ -12,13 +12,14 @@
     <section class="section">
         <div class="container content">
             <h1 class="title is-1">SubBox Import</h1>
-            <p>Import to sub-box from your DJ software</p>
+            <p>Import to sub-box from your Rekordbox collection.</p>
             <h1 class="subtitle is-3">Rekordbox</h1>
             <p>Tested with Rekordbox 5.8.7 and Rekordbox 6.8.0. It should also work with other rekordbox versions.</p>
-            <p>To import from RB 5</p>
+            <p>To import from Rekordbox</p>
             <ol>
                 <li>export your RB collection (From rekordbox desktop app: File->Library->Backup Library). Make sure you select 'yes' to backing up music files as well. This will create a 'rekordbox_bak' folder with the music files in. It will also create a zip folder but this is not needed.</li>
-                <li>backup your collection as xml (File -> Export Collection in xml format). This contains all the playlist data neeted to create your playlists in subbox.</li>
+                <li>To decrease the time it takes to import your collection to subbox, create a zip of the 'rekordbox_bak' directory made in the above step. Call it 'rekordbox_bak.zip'.</li>
+                <li>backup your collection as xml (File -> Export Collection in xml format). Save it as 'rekordbox-backup.xml'. This contains all the playlist data needed to create your playlists in subbox.</li>
             </ol>
             <p>Once the above has been completed in rekordbox, upload the resulting xml and rekordbox_bak directory containing the tracks to subbox <a href="/upload">here</a>. Then click process below.</p>
             <div id="rb-process-content">

--- a/subbox_landing/ui/templates/dj/serato_export.html
+++ b/subbox_landing/ui/templates/dj/serato_export.html
@@ -12,11 +12,41 @@
     <section class="section">
         <div class="container content">
             <h1 class="title is-1">DJ export</h1>
-            <p>Export to your DJ software</p>
+            <p>Export from sub-box to your DJ software</p>
             <div id="rb-export">
                 <h1 class="subtitle is-1">Export</h1>
                 <h1 class="subtitle is-3">Serato DJ Pro</h1>
-                <p>Coming soon!</p>
+                <p>Tested with Serato DJ Pro Version 3.1.1. It should also work for other versions.</p>
+                <p>
+                    export your collection and playlists in sub box to Serato (from Serato you can then play through your hardware DJ system.
+                </p>
+                <p>
+                    To get started, fill out the form below and click export.
+                    When this completes, it will prepare a zip file that you can download to your computer.
+                    The zip contains your updated music collection and a Serato Crates directory, containing the crate information for Serato.
+                    Once you have downloaded the zip from subbox to your computer you will need to unzip the audio files in the path you set in the 'local root' box below.
+                    Finally, you will need to drag and drop the downloaded serato crates directory from subbox in to your local Serato subcrates directory (by default located at ~/Music/_Serato_/Subcrates).
+                </p>
+                <form id="exportform">
+                    <div>
+                        <label>local root</label>
+                        <input type="text" name="local_root" value="<enter-here>">
+                        <p>set the local root for where you will extract the zip of the audio files on your system. For example: `/Users/bob/subbox`</p>
+                    </div>
+                    <p>Note that for a large collection, this could take several minutes.</p>
+                    <!-- todo do some validation here and only show the progress button iff there are uploaded tracks-->
+                    <button class="button is-primary" hx-post="/djs/export/serato" hx-target="#rb-export" hx-indicator="#spinner" hx-swap="outerHTML">
+                        Export
+                        <img id="spinner" class="htmx-indicator loader" src="/imgs/spin">
+                    </button>
+                </form>
+                <p>
+                    Once this completes successfully, download the zip <a href="/download">here</a>.
+                </p>
+                <h1 class="subtitle is-4">Importing crates from subbox in to Serato.</h1>
+                <p>
+                    drag and drop the downloaded Serato crates directory from subbox in to your local Serato subcrates directory (by default located at ~/Music/_Serato_/Subcrates).
+                </p>
             </div>
         </div>
     </section>

--- a/subbox_landing/ui/templates/dj/serato_import.html
+++ b/subbox_landing/ui/templates/dj/serato_import.html
@@ -11,11 +11,33 @@
     </header>
     <section class="section">
         <div class="container content">
-            <h1 class="title is-1">DJ Import</h1>
-            <p>Import from your DJ software</p>
-            <h1 class="subtitle is-1">Import</h1>
+            <h1 class="title is-1">SubBox Import</h1>
+            <p>Import to sub-box from your Serato collection.</p>
             <h1 class="subtitle is-3">Serato DJ Pro</h1>
-            <p>Coming soon!</p>
+            <p>Tested with Serato DJ Pro Version 3.1.1. It should also work for other versions.</p>
+            <p>To import from Serato DJ Pro</p>
+            <ol>
+                <li>Zip up your audio files and call it 'audio_files.zip'</li>
+                <li>Zip up your subcrates folder (located ~/Music/_Serato_/SubCrates). Call it 'SubCrates.zip'.</li>
+            </ol>
+            <p>Once you have completed the above, upload the two zip files to subbox <a href="/upload">here</a>. Then click process below.</p>
+            <div id="serato-process-content">
+                <div hx-post="/djs/upload/serato" hx-trigger="start-serato-import from:body" hx-target="#serato-process-content" hx-swap="outerHTML" hx-indicator="#spinner">
+                </div>
+
+                <div id="serato-import">
+                    <div id="process">
+                        <p>
+                            Process uploaded serato collection.
+                        </p>
+                    </div>
+                    <p>
+                        once you have uploaded the two zip files, click the process music button. This will import your collection.
+                    </p>
+                    <!-- todo do some validation here and only show the progress button iff there are uploaded tracks-->
+                    <button id="start-serato-upload" hx-target="#serato-import" hx-swap="outerHTML" hx-get="/job/progress" class="button is-primary" hx-vals='{"type": "start-serato-import"}'>
+                        process
+                    </button>
         </div>
     </section>
 {% endblock %}

--- a/subbox_landing/ui/templates/partials/job_progress.html
+++ b/subbox_landing/ui/templates/partials/job_progress.html
@@ -6,19 +6,19 @@
               <progress class="progress is-success" value="{{ percentage_complete }}" max="100">{{ percentage_complete }}%</progress>
           </div>
         {% endif %}
-        <p>Imported {{ percentage_complete }} % out of a total of {{ n_tracks_to_import }} tracks.</p>
+        <p>Imported {{ n_tracks_imported }} out of a total of {{ n_tracks_to_import }} tracks ( {{ percentage_complete }} % ).</p>
         {% if percentage_complete >= 100 %}
           <p>Import almost complete! Finalising...</p>
           <img id="spinner" class="loader" src="/imgs/spin">
         {% else %}
           {% if n_tracks_to_import < 50 %}
-          <p>This shouldn't take long. :)</p>
+          <p>This shouldn't take long.</p>
           {% elif n_tracks_to_import < 100 %}
-          <p>This may take a few minutes. :)</p>
+          <p>This may take a few minutes...</p>
           {% elif n_tracks_to_import < 500 %}
-          <p>This may take a few minutes... Go make a cup of tea. :)</p>
+          <p>This may take a few minutes... Go make a cup of tea.</p>
           {% elif n_tracks_to_import < 1000 %}
-          <p>This may take an hour or so... Go have a nap. :)</p>
+          <p>This may take an hour or so... Go for a walk.</p>
           {% endif %}
         {% endif %}
     </section>

--- a/subbox_landing/ui/templates/partials/serato_export_results.html
+++ b/subbox_landing/ui/templates/partials/serato_export_results.html
@@ -1,0 +1,7 @@
+<section class="section">
+  <div class="container">
+      <h1> success </h1>
+      <p> total number of tracks exported {{ n_beets_tracks }}</p>
+      <p> please go to filebrowser and download sub box audio file zip and serato crates zip. Then extract the audio files to the root path you configured and drag the unzipped crates to your Serato subcrate directory (~/Music/_Serato_/Subcrates).</p>
+  </div>
+</section>


### PR DESCRIPTION
* introduce config for dev and prod deployments to enable local testing
* add logic for serato import and export.
* bug fixes from testing sub box to serato export
* display n_tracks_imported as well as percentage complete in progress job bar
* take success from end point response
* typo fixes
* fix path of html files given the default project working directory set when running runner.py entry point